### PR TITLE
New Search UI overhaul, HP Start, nixpacks commands

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'name' => env('APP_NAME', 'Audio Word Finder'),
+    'name' => env('APP_NAME', 'Search My Audio'),
 
     /*
     |--------------------------------------------------------------------------

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,17 +1,29 @@
 [phases.setup]
 nixPkgs = ["...", "python311Packages.supervisor"]
 
+[phases.install]
+cmds = [
+    "composer config http-basic.composer.fluxui.dev isaacbraun2000@gmail.com 9137a3c1-3b33-44fe-ae4d-2aa5626f2aa9",
+    "composer install --no-dev",
+    "..."
+]
+
 [phases.build]
 cmds = [
     "mkdir -p /etc/supervisor/conf.d/",
     "cp /assets/worker-*.conf /etc/supervisor/conf.d/",
     "cp /assets/supervisord.conf /etc/supervisord.conf",
     "chmod +x /assets/start.sh",
+    "npm ci --audit false",
+    "npm run build",
     "..."
 ]
 
 [start]
-cmd = '/assets/start.sh'
+cmds = [
+    "/assets/start.sh",
+    "php artisan migrate --force",
+]
 
 [staticAssets]
 "start.sh" = '''

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -46,6 +46,30 @@
     }
 }
 
+@utility auto-fill-min-*{
+  grid-template-columns: repeat(auto-fill, minmax(min(--value([*]), 100%), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(--value(--text-*), 100%), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(var(--spacing)* --value(integer), 100%), 1fr));
+}
+
+@utility auto-fill-max-*{
+  grid-template-columns: repeat(auto-fill, minmax(max(--value([*]), 100%), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(max(--value(--text-*), 100%), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(max(var(--spacing)* --value(integer), 100%), 1fr));
+}
+
+@utility auto-fit-min-*{
+  grid-template-columns: repeat(auto-fit, minmax(min(--value([*]), 100%), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(--value(--text-*), 100%), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(var(--spacing)* --value(integer), 100%), 1fr));
+}
+
+@utility auto-fit-max-*{
+  grid-template-columns: repeat(auto-fit, minmax(max(--value([*]), 100%), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(max(--value(--text-*), 100%), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(max(var(--spacing)* --value(integer), 100%), 1fr));
+}
+
 [data-flux-field] {
     @apply grid gap-2;
 }

--- a/resources/views/components/app-logo.blade.php
+++ b/resources/views/components/app-logo.blade.php
@@ -2,5 +2,5 @@
     <x-app-logo-icon />
 </div>
 <div class="ml-1 grid flex-1 text-left text-sm">
-    <span class="mb-0.5 truncate leading-none font-semibold">Audio Word Finder</span>
+    <span class="mb-0.5 truncate leading-none font-semibold">{{ config('app.name') }}</span>
 </div>

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <x-layouts.app.header :title="$title ?? null">
-    <flux:main container id="content">
+    <flux:main container id="content" class="!py-8 !lg:py-12">
         {{ $slot }}
     </flux:main>
 

--- a/resources/views/components/layouts/app/header.blade.php
+++ b/resources/views/components/layouts/app/header.blade.php
@@ -88,7 +88,7 @@
             </flux:menu>
         </flux:dropdown>
         @else
-        <flux:button size="sm" class="mr-2" :href="route('login')" wire:navigate.hover>
+        <flux:button size="sm" variant="ghost" class="mr-4" :href="route('login')" wire:navigate.hover>
             {{ __('Log In') }}
         </flux:button>
         <flux:button size="sm" variant="primary" :href="route('register')" wire:navigate.hover>

--- a/resources/views/components/layouts/app/header.blade.php
+++ b/resources/views/components/layouts/app/header.blade.php
@@ -13,7 +13,7 @@
         </ul>
     </nav>
 
-    <flux:header id="navigation" container class="sticky top-0 border-b border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">
+    <flux:header id="navigation" container class="sticky top-0 ">
         @auth
         <flux:sidebar.toggle class="lg:hidden" icon="bars-2" inset="left" />
         @else

--- a/resources/views/livewire/history.blade.php
+++ b/resources/views/livewire/history.blade.php
@@ -54,10 +54,11 @@ new #[Title('History')] class extends Component {
 
 <div>
     <flux:heading size="xl" level="1">History</flux:heading>
+    <flux:subheading>View and delete past searches.</flux:subheading>
 
     <livewire:confirm-delete @delete="delete" name="delete-search" />
 
-    <flux:table :paginate="$this->searches">
+    <flux:table :paginate="$this->searches" class="mt-12">
         <flux:table.columns>
             <flux:table.column sortable :sorted="$sortBy === 'query'" :direction="$sortDirection" wire:click="sort('query')">Query</flux:table.column>
             <flux:table.column sortable :sorted="$sortBy === 'query_total'" :direction="$sortDirection" wire:click="sort('query_total')">Matches</flux:table.column>

--- a/resources/views/livewire/home.blade.php
+++ b/resources/views/livewire/home.blade.php
@@ -12,7 +12,7 @@ new class extends Component {
             Search and Chat with<em> Your </em>Audio Files
         </flux:heading>
         <flux:subheading class="!text-2xl text-center mt-4 max-w-[35ch]">
-            Effortlessly transcribe, search, and ask questions about textual content from your audio files.
+            Effortlessly transcribe, search, and ask questions about textual content found in your audio files.
         </flux:subheading>
         <div class="mt-8">
             @auth
@@ -26,54 +26,54 @@ new class extends Component {
             @endauth
         </div>
     </section>
-    <section>
-        <flux:heading level="2" size="xl" class="text-4xl text-center">What Can You Do?</flux:heading>
-        <flux:subheading>Maybe make this a tabbed list with the features on the left as tabs and content explanation/demos on the right</flux:subheading>
-        <div class="grid auto-fill-min-[300px] gap-6 mt-8">
-            <flux:card>
-                <flux:heading size="lg" class="mb-4">Search</flux:heading>
-                <flux:text>Find where and how many times a word or query was spoken throughout your files</flux:text>
-                    <li>View where queries where found</li>
-                    <li>See total count of
-            </flux:card>
-            <flux:card>
-                <flux:heading size="lg"></flux:heading>
-                <flux:text>Find where and how many times a word or query was spoken throughout your files</flux:text>
-            </flux:card>
-            <flux:card>
-                <flux:heading size="lg">Search</flux:heading>
-                <flux:text>Find where and how many times a word or query was spoken throughout your files</flux:text>
-            </flux:card>
-            <flux:card>
-                <flux:heading size="lg">Search</flux:heading>
-                <flux:text>Find where and how many times a word or query was spoken throughout your files</flux:text>
-            </flux:card>
-        </div>
-    </section>
-    <section>
-        <flux:heading level="2" size="xl" class="text-4xl text-center">What Does it Cost?</flux:heading>
-        <div class="flex flex-row flex-wrap justify-center gap-6 mt-8">
-            <flux:card class="min-w-sm">
-                <flux:heading size="xl">Free</flux:heading>
-                <flux:subheading>Simple but powerful</flux:subheading>
-                Use colors to show differences in features
-                <ul class="mt-6">
-                    <li>All basic features</li>
-                    <li>25MB per file limit</li>
-                    <li>Search 1 file at a time</li>
-                </ul>
-            </flux:card>
-            <flux:card class="min-w-sm">
-                <flux:heading size="xl">Premium - $10/month</flux:heading>
-                <flux:subheading>Unleash the searching</flux:subheading>
-                <ul class="mt-6">
-                    <li>Transcribe and search audio files</li>
-                    <li>25MB per file limit</li>
-                    <li>Search unlimited files at once</li>
-                    <li>View search history</li>
-                    <li>Chat about all searches</li>
-                </ul>
-            </flux:card>
-        </div>
-    </section>
+    <!-- <section> -->
+    <!--     <flux:heading level="2" size="xl" class="text-4xl text-center">What Can You Do?</flux:heading> -->
+    <!--     <flux:subheading>Maybe make this a tabbed list with the features on the left as tabs and content explanation/demos on the right</flux:subheading> -->
+    <!--     <div class="grid auto-fill-min-[300px] gap-6 mt-8"> -->
+    <!--         <flux:card> -->
+    <!--             <flux:heading size="lg" class="mb-4">Search</flux:heading> -->
+    <!--             <flux:text>Find where and how many times a word or query was spoken throughout your files</flux:text> -->
+    <!--                 <li>View where queries where found</li> -->
+    <!--                 <li>See total count of -->
+    <!--         </flux:card> -->
+    <!--         <flux:card> -->
+    <!--             <flux:heading size="lg"></flux:heading> -->
+    <!--             <flux:text>Find where and how many times a word or query was spoken throughout your files</flux:text> -->
+    <!--         </flux:card> -->
+    <!--         <flux:card> -->
+    <!--             <flux:heading size="lg">Search</flux:heading> -->
+    <!--             <flux:text>Find where and how many times a word or query was spoken throughout your files</flux:text> -->
+    <!--         </flux:card> -->
+    <!--         <flux:card> -->
+    <!--             <flux:heading size="lg">Search</flux:heading> -->
+    <!--             <flux:text>Find where and how many times a word or query was spoken throughout your files</flux:text> -->
+    <!--         </flux:card> -->
+    <!--     </div> -->
+    <!-- </section> -->
+    <!-- <section> -->
+    <!--     <flux:heading level="2" size="xl" class="text-4xl text-center">What Does it Cost?</flux:heading> -->
+    <!--     <div class="flex flex-row flex-wrap justify-center gap-6 mt-8"> -->
+    <!--         <flux:card class="min-w-sm"> -->
+    <!--             <flux:heading size="xl">Free</flux:heading> -->
+    <!--             <flux:subheading>Simple but powerful</flux:subheading> -->
+    <!--             Use colors to show differences in features -->
+    <!--             <ul class="mt-6"> -->
+    <!--                 <li>All basic features</li> -->
+    <!--                 <li>25MB per file limit</li> -->
+    <!--                 <li>Search 1 file at a time</li> -->
+    <!--             </ul> -->
+    <!--         </flux:card> -->
+    <!--         <flux:card class="min-w-sm"> -->
+    <!--             <flux:heading size="xl">Premium - $10/month</flux:heading> -->
+    <!--             <flux:subheading>Unleash the searching</flux:subheading> -->
+    <!--             <ul class="mt-6"> -->
+    <!--                 <li>Transcribe and search audio files</li> -->
+    <!--                 <li>25MB per file limit</li> -->
+    <!--                 <li>Search unlimited files at once</li> -->
+    <!--                 <li>View search history</li> -->
+    <!--                 <li>Chat about all searches</li> -->
+    <!--             </ul> -->
+    <!--         </flux:card> -->
+    <!--     </div> -->
+    <!-- </section> -->
 </div>

--- a/resources/views/livewire/home.blade.php
+++ b/resources/views/livewire/home.blade.php
@@ -6,6 +6,74 @@ new class extends Component {
     //
 }; ?>
 
-<div>
-    <flux:heading level="1" size="xl">Welcome</flux:heading>
+<div class="mt-12 flex flex-col gap-24">
+    <section class="flex flex-col items-center">
+        <flux:heading level="1" size="xl" class="leading-24 text-7xl text-center max-w-[15ch]">
+            Search and Chat with<em> Your </em>Audio Files
+        </flux:heading>
+        <flux:subheading class="!text-2xl text-center mt-4 max-w-[35ch]">
+            Effortlessly transcribe, search, and ask questions about textual content from your audio files.
+        </flux:subheading>
+        <div class="mt-8">
+            @auth
+            <flux:button variant="primary" :href="route('new')" wire:navigate.hover>
+                {{ __('Get Started') }}
+            </flux:button>
+            @else
+            <flux:button variant="primary" :href="route('register')" wire:navigate.hover>
+                {{ __('Get Started') }}
+            </flux:button>
+            @endauth
+        </div>
+    </section>
+    <section>
+        <flux:heading level="2" size="xl" class="text-4xl text-center">What Can You Do?</flux:heading>
+        <flux:subheading>Maybe make this a tabbed list with the features on the left as tabs and content explanation/demos on the right</flux:subheading>
+        <div class="grid auto-fill-min-[300px] gap-6 mt-8">
+            <flux:card>
+                <flux:heading size="lg" class="mb-4">Search</flux:heading>
+                <flux:text>Find where and how many times a word or query was spoken throughout your files</flux:text>
+                    <li>View where queries where found</li>
+                    <li>See total count of
+            </flux:card>
+            <flux:card>
+                <flux:heading size="lg"></flux:heading>
+                <flux:text>Find where and how many times a word or query was spoken throughout your files</flux:text>
+            </flux:card>
+            <flux:card>
+                <flux:heading size="lg">Search</flux:heading>
+                <flux:text>Find where and how many times a word or query was spoken throughout your files</flux:text>
+            </flux:card>
+            <flux:card>
+                <flux:heading size="lg">Search</flux:heading>
+                <flux:text>Find where and how many times a word or query was spoken throughout your files</flux:text>
+            </flux:card>
+        </div>
+    </section>
+    <section>
+        <flux:heading level="2" size="xl" class="text-4xl text-center">What Does it Cost?</flux:heading>
+        <div class="flex flex-row flex-wrap justify-center gap-6 mt-8">
+            <flux:card class="min-w-sm">
+                <flux:heading size="xl">Free</flux:heading>
+                <flux:subheading>Simple but powerful</flux:subheading>
+                Use colors to show differences in features
+                <ul class="mt-6">
+                    <li>All basic features</li>
+                    <li>25MB per file limit</li>
+                    <li>Search 1 file at a time</li>
+                </ul>
+            </flux:card>
+            <flux:card class="min-w-sm">
+                <flux:heading size="xl">Premium - $10/month</flux:heading>
+                <flux:subheading>Unleash the searching</flux:subheading>
+                <ul class="mt-6">
+                    <li>Transcribe and search audio files</li>
+                    <li>25MB per file limit</li>
+                    <li>Search unlimited files at once</li>
+                    <li>View search history</li>
+                    <li>Chat about all searches</li>
+                </ul>
+            </flux:card>
+        </div>
+    </section>
 </div>

--- a/resources/views/livewire/new.blade.php
+++ b/resources/views/livewire/new.blade.php
@@ -98,7 +98,7 @@ new #[Title('New')] class extends Component
 
 <div x-data="uploadHandler">
     <flux:heading size="xl" level="1">Create a new search</flux:heading>
-    <flux:subheading>Upload your audio files, then enter your search query.</flux:subheading>
+    <flux:subheading>Upload audio files to search their transcripts.</flux:subheading>
 
     <form wire:submit.prevent="submitFiles" class="mt-12">
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-16">

--- a/resources/views/livewire/new.blade.php
+++ b/resources/views/livewire/new.blade.php
@@ -104,8 +104,6 @@ new #[Title('New')] class extends Component
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-16">
             <div class="row-start-2 lg:col-span-2 lg:row-span-2">
                 <flux:field>
-                    <flux:error name="uploadedFiles" />
-
                     @if (Auth::user()->subscribed())
                     <input hidden multiple type="file" accept="audio/*" id="fileInput" @change="onFileInputChanged" />
                     @else
@@ -121,6 +119,8 @@ new #[Title('New')] class extends Component
                             <flux:text class="pointer-events-none"><span class="underline font-bold">Choose</span> or drop audio files</flux:text>
                         </flux:card>
                     </flux:label>
+
+                    <flux:error name="uploadedFiles" />
                 </flux:field>
 
                 <div class="flex flex-row flex-wrap gap-2 items-end justify-between mt-10">
@@ -145,7 +145,7 @@ new #[Title('New')] class extends Component
                         <flux:subheading>Invalid files will NOT be uploaded.</flux:subheading>
                     </div>
 
-                    <flux:button inset x-cloak x-show="localFiles.length > 0" size="sm" @click="clear" label="Remove all files from upload queue" variant="ghost">
+                    <flux:button inset="top bottom" x-cloak x-show="localFiles.length > 0" size="sm" @click="clear" label="Remove all files from upload queue" variant="ghost">
                         Clear All
                     </flux:button>
                 </div>

--- a/resources/views/livewire/results.blade.php
+++ b/resources/views/livewire/results.blade.php
@@ -132,7 +132,7 @@ new class extends Component {
             @elseif ($search->status === SearchStatus::Completed && $search->query_total > 0)
             <flux:callout.heading>
                 Processing Completed
-                <flux:text>{{ $search->query_total }} Total {{ Str::plural('Match', $search->query_total) }}</flux:text>
+                <flux:text>{{ $search->query_total }} total {{ Str::plural('match', $search->query_total) }}</flux:text>
             </flux:callout.heading>
 
             @if (Auth::user()->subscribed() && $search->report_path !== null)

--- a/resources/views/livewire/results.blade.php
+++ b/resources/views/livewire/results.blade.php
@@ -123,7 +123,7 @@ new class extends Component {
 
     <!-- Processing status/results -->
     <div @if ($search->status !== SearchStatus::Completed) wire:poll.2s @endif>
-        <flux:callout class="my-8" inline color="{{ $this->status['color'] }}" icon="{{ $this->status['icon'] }}">
+        <flux:callout class="mb-4" inline color="{{ $this->status['color'] }}" icon="{{ $this->status['icon'] }}">
             @if ($search->status === SearchStatus::Processing)
             <flux:callout.heading class="justify-between">
                 Processing {{ count($search->files) }} {{ Str::plural('file', count($search->files)) }}

--- a/resources/views/livewire/results.blade.php
+++ b/resources/views/livewire/results.blade.php
@@ -110,11 +110,11 @@ new class extends Component {
 }; ?>
 
 <div>
-    <div class="flex flex-row flex-wrap items-center justify-between gap-2">
+    <div class="flex flex-row flex-wrap items-center justify-between gap-2 mb-12">
         <flux:heading size="xl" level="1">Results for "{{ $query }}"</flux:heading>
 
         <flux:modal.trigger name="delete-search">
-            <flux:button size="sm" variant="danger" icon="trash">Delete</flux:button>
+            <flux:button size="sm" icon="trash">Delete</flux:button>
         </flux:modal.trigger>
     </div>
 


### PR DESCRIPTION
- **chore: add min/max auto grid cols**
- **chore: fix casing inconsistencies**
- **feat: rework UI, allow for adding additional files, fix clear**
- **chore: align content below header and make delete button default**
- **chore: update app name**
- **chore: make log in button ghost (less attention)**
- **chore: move file input error below box, inset clear button on top/bottom**
- **feat: initial homepage mock**
- **chore: move status closer to results**
- **feat: remove header color/border**
- **chore: increase vertical padding on container**
- **feat: add flux pro and build commands**
- **temp hide content**
