### PR TITLE
Dark Mode Header - TESTing transcription path

### DIFF
--- a/resources/views/components/layouts/app/header.blade.php
+++ b/resources/views/components/layouts/app/header.blade.php
@@ -13,7 +13,7 @@
         </ul>
     </nav>
 
-    <flux:header id="navigation" container class="sticky top-0 bg-white shadow-sm shadow-gray-200">
+    <flux:header id="navigation" container class="sticky top-0 bg-white shadow-sm shadow-gray-200 dark:bg-zinc-900 dark:shadow-zinc-900">
         @auth
         <flux:sidebar.toggle class="lg:hidden" icon="bars-2" inset="left" />
         @else

--- a/resources/views/livewire/file-results.blade.php
+++ b/resources/views/livewire/file-results.blade.php
@@ -83,8 +83,6 @@ new class extends Component
                 @endif
             </div>
 
-            <p>{{ $this->file->transcription_path }}</p>
-
             @if (!$this->transcription && !$this->failed)
             <flux:icon.loading variant="micro" />
             @elseif (Arr::has($this->transcription, "fullText"))
@@ -98,7 +96,8 @@ new class extends Component
             @endif
         </div>
 
-        <p>{{ $this->transcription }}</p>
+        <p>{{ var_dump($this->file->transcription_path) }}</p>
+        <p>{{ var_dump($this->transcription) }}</p>
 
         @if ($this->transcription)
         <flux:accordion class="mt-2" variant="reverse">


### PR DESCRIPTION
- **chore: replace aws with r2**
- **chore: r2 fixes**
- **add back simple bg and shadow to header**
- **chore: build before artisan commands, add queue**
- **fix: run queue:work in start**
- **remove queue command, add db to sh command**
- **chore: log transcription path/result**
- **change start to one command**
- **test: output values for testing**
- **test: fix var path**
- **fix: add back dark mode header classes**
- **fix: still testing transcription result**
