### PR TITLE
fix(search): check if query_total is not null instead of gt zero

### DIFF
--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -126,12 +126,9 @@ class Search extends Model
      */
     public function addToQueryCount(int $count): void
     {
-        Log::info('Adding to query count: ' . $count);
-        if (isset($this->query_total) && $this->query_total > 0) {
-            Log::info('Adding to existing: ' . $this->query_total);
+        if (isset($this->query_total) && $this->query_total !== null) {
             $this->query_total += intval($count);
         } else {
-            Log::info('Initializing query total: ' . $count);
             $this->query_total = intval($count);
         }
 

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -120,13 +120,13 @@ class Search extends Model
     /**
      * Increments the query total for the search by the specified count.
      *
-     * If the query total is not set or is zero, it initializes it with the given count.
+     * If the query total is not set, it initializes it with the given count.
      *
      * @param int $count The number to add to the query total.
      */
     public function addToQueryCount(int $count): void
     {
-        if (isset($this->query_total) && $this->query_total !== null) {
+        if (isset($this->query_total)) {
             $this->query_total += intval($count);
         } else {
             $this->query_total = intval($count);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of query count updates to ensure accurate tracking, even when the current value is zero or negative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->