### PR TITLE
Remove Query Total Error Callouts

### DIFF
--- a/resources/views/livewire/history.blade.php
+++ b/resources/views/livewire/history.blade.php
@@ -57,15 +57,6 @@ new #[Title('History')] class extends Component
 }; ?>
 
 <div>
-    <flux:callout icon="bell" variant="warning" class="mb-8" inline>
-        <flux:callout.heading>
-            There is an error with some total match counts
-        </flux:callout.heading>
-        <flux:callout.text>
-            We're working to fix it as soon as possible. We apologize for the inconvenience.
-        </flux:callout.text>
-    </flux:callout>
-
     <flux:heading size="xl" level="1">History</flux:heading>
     <flux:subheading>View and delete past searches.</flux:subheading>
 

--- a/resources/views/livewire/results.blade.php
+++ b/resources/views/livewire/results.blade.php
@@ -115,15 +115,6 @@ new class extends Component {
 }; ?>
 
 <div>
-    <flux:callout icon="bell" variant="warning" class="mb-8" inline>
-        <flux:callout.heading>
-            There is an error with some total match counts
-        </flux:callout.heading>
-        <flux:callout.text>
-            We're working to fix it as soon as possible. We apologize for the inconvenience.
-        </flux:callout.text>
-    </flux:callout>
-
     <div class="flex flex-row flex-wrap items-center justify-between gap-2 mb-12">
         <flux:heading size="xl" level="1">Results for "{{ $query }}"</flux:heading>
 


### PR DESCRIPTION
- **fix(search): check if query_total is not null instead of gt zero**
- **fix(search): remove duplicate null check**
- **fix(Search): another attempt to fix query total using atomic operations**
- **fix(Search): use more verbose queries to avoid race conditions**
- **chore(pages): remove alerts for query total issue**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed warning callout messages from the history and results views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->