### PR TITLE
chore(nixpacks): add max execution time

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -109,6 +109,7 @@ pm.start_servers = 18
 clear_env = no
 php_admin_value[post_max_size] = 35M
 php_admin_value[upload_max_filesize] = 30M
+php_admin_value[max_execution_time] = 300
 '''
 
 "nginx.template.conf" = '''


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum execution time for PHP scripts to 300 seconds, allowing longer-running processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->